### PR TITLE
Adding initheaders to put requests for new entities

### DIFF
--- a/lib/bullhorn/rest/entities/base.rb
+++ b/lib/bullhorn/rest/entities/base.rb
@@ -121,7 +121,7 @@ module Bullhorn
               if ids = options.delete(:association_ids)
                 path += "/#{ids.to_s}"
               end
-              res = conn.put path, attributes.to_json
+              res = conn.put path, attributes.to_json, initheader = {'Content-Type' => 'application/json'}
               Hashie::Mash.new JSON.parse(res.body)
             end
 


### PR DESCRIPTION
After authorization, initheaders for JSON type will sometimes drop. Not sure if this is the root cause, but adding for consistency after authorization.